### PR TITLE
GOV PaaS Guide

### DIFF
--- a/deploying/gov-paas.md
+++ b/deploying/gov-paas.md
@@ -1,7 +1,22 @@
 # Deploying to GOV PaaS
 
-[GOV PaaS](https://www.cloud.service.gov.uk/) gives public sector teams an approved cloud environment to host applications. It is built on top of the open source [Cloud Foundry](https://github.com/cloudfoundry) platform.
+[GOV Platform as a Service (PaaS)](https://www.cloud.service.gov.uk/) is like Heroku for public sector projects. It allows public sector teams to host applications in a government approved cloud environment. It is built on top of the open source [Cloud Foundry](https://github.com/cloudfoundry) platform.
 
-## Prerequisites
+## Documentation
 
-- To set up a GOV PaaS account you need a `.gov.uk` email. This email will usually be responsible for managing applications across an orgnanisation. If the organisation doesn't already have a GOV PaaS account, the infrastructure / IT team should be responsible for setting it up.
+[The official Platform as a Service docs](https://docs.cloud.service.gov.uk/#gov-uk-platform-as-a-service) should always be your first port of call. This guide serves more as evolving checklist of helpful tips to help you get set up for success.
+
+## Important questions to ask the client
+
+- Will the system need to store data classified as higher than official? If yes: we can't use Gov PaaS.
+- Do you already have a Gov PaaS account?
+- Who manages your IT / infrastructure?
+- Who should involve from an IT / Infrastructure?
+- Who will be managing this service in production?
+- What application monitoring tools do you use?
+- What log monitoring tools do you use?
+
+## Checklist
+
+- [ ] **To set up a GOV PaaS account you need a `.gov.uk` email.** This email account will often be responsible for managing applications across an orgnanisation. If the organisation doesn't already have a GOV PaaS account, the infrastructure / IT team should be responsible for setting it up. If they do have an account, we will want to work closely with the team who manages it from as early as possible in the project.
+- [ ] **Create a `manifest.yml` file in the root of your repository.** GOV PaaS uses a configuration file to provision and deploy your app.

--- a/deploying/gov-paas.md
+++ b/deploying/gov-paas.md
@@ -1,0 +1,7 @@
+# Deploying to GOV PaaS
+
+[GOV PaaS](https://www.cloud.service.gov.uk/) gives public sector teams an approved cloud environment to host applications. It is built on top of the open source [Cloud Foundry](https://github.com/cloudfoundry) platform.
+
+## Prerequisites
+
+- To set up a GOV PaaS account you need a `.gov.uk` email. This email will usually be responsible for managing applications across an orgnanisation. If the organisation doesn't already have a GOV PaaS account, the infrastructure / IT team should be responsible for setting it up.


### PR DESCRIPTION
We are deploying to GOV PaaS on the [Connected Camden](https://github.com/WeAreSnook/connected-camden) project. As outlined in [the ticket to setup Gov Paas](https://github.com/WeAreSnook/connected-camden/issues/78), we want to document how to go about setting up and deploying to GOV PaaS for future projects.

This PR will be used to document the process of getting setup and deploying to the platform and things to watch out for.

When merged closes #18 